### PR TITLE
Revert "Add dist to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,5 +152,3 @@ $RECYCLE.BIN/
 
 package-lock.json
 yarn.lock
-
-dist


### PR DESCRIPTION
Reverts EmakinaTR/makina-app#26

Docker keeps out files and folders in .gitignore out of its image building context. Therefore fails to build the image since "dist" is ignored and doesn't exist in its context.